### PR TITLE
Handle optional UI static assets gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 import contextlib
 import os
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -12,7 +13,6 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from pathlib import Path
 from pydantic import BaseModel
 
 # Load environment variables from a local .env file when present.

--- a/app.py
+++ b/app.py
@@ -10,6 +10,9 @@ from dotenv import load_dotenv
 from elasticsearch import Elasticsearch, TransportError
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from pydantic import BaseModel
 
 # Load environment variables from a local .env file when present.
@@ -46,19 +49,22 @@ app.add_middleware(
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse
-from pathlib import Path
 
-# Serve static UI files from /ui folder
-app.mount("/ui", StaticFiles(directory="ui", html=True), name="ui")
+BASE_DIR = Path(__file__).resolve().parent
+UI_DIR = BASE_DIR / "ui"
 
-# Serve index.html directly (fallback)
+if UI_DIR.exists():
+    app.mount("/ui", StaticFiles(directory=str(UI_DIR), html=True), name="ui.index")
+
+
 @app.get("/index.html", response_class=HTMLResponse)
-def serve_index():
-    path = Path("ui/index.html")
-    if path.exists():
-        return path.read_text(encoding="utf-8")
+def serve_index() -> str:
+    """Serve the bundled UI index file when present."""
+
+    for candidate in (UI_DIR / "index.html", BASE_DIR / "index.html"):
+        if candidate.exists():
+            return candidate.read_text(encoding="utf-8")
+
     return "<h1>index.html not found</h1>"
 
 


### PR DESCRIPTION
## Summary
- load FastAPI static files only when the optional ui directory exists
- serve the HTML index from either ui/index.html or the repository root fallback
- document the updated behaviour with a clearer docstring

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e43a457434833092d05eadda9ce3aa